### PR TITLE
[Feature]: Update Changelog, OSS Community Files, and README + Add CI Badge (Closes narainkarthikv/Portfolio#40)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+Explain the changes and why they’re needed.
+
+## Linked Issues
+Closes #
+
+## Changes
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Docs
+- [ ] CI/CD
+
+## Screenshots/Notes
+(Optional)
+
+## Checklist
+- [ ] I have updated docs (README/CHANGELOG) as needed.
+- [ ] CI passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/),
+and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-08-11
+### Added
+- Initial public changelog.
+- GitHub Pages workflow for static deployment (`.github/workflows/static.yml`) targeting `./legacy/`.
+- Issue templates for bug, feature, and other requests.
+- Repository documentation baseline: README, LICENSE.
+
+[Unreleased]: https://github.com/narainkarthikv/Portfolio/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/narainkarthikv/Portfolio/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project adopts the Contributor Covenant Code of Conduct, version 2.1.
+
+- Homepage: https://www.contributor-covenant.org
+- Full text: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+- Translations: https://www.contributor-covenant.org/translations
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at the email listed on their GitHub profile. Reports will be handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Portfolio
+
+Thanks for your interest in contributing!
+
+## Ways to Contribute
+- Report bugs via Issues (use the Bug template).
+- Propose features (use the Feature template).
+- Improve docs and examples.
+- Tackle issues labeled good first issue / help wanted.
+
+## Development Setup
+- Fork and clone your fork.
+- Create a feature branch from `main`.
+- This is a static site. Content is under the repository root and `legacy/` (deployment path).
+- Preview locally using any static server, for example:
+  - `npx serve .` or `python -m http.server`
+  - If using `legacy/`: `npx serve legacy`
+
+## Pull Requests
+- Keep PRs focused and link the related issue, e.g., "Closes #40".
+- Update docs (README/CHANGELOG) as needed.
+- Ensure CI passes.
+
+## Code of Conduct
+By participating, you agree to uphold the Code of Conduct. See `CODE_OF_CONDUCT.md`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![SVG Banners](https://svg-banners.vercel.app/api?type=luminance&text1=Wisdom%20Fox&width=1000&height=200)](https://github.com/narainkarthikv/svg-banners)
+[![Deploy static content to Pages](https://github.com/narainkarthikv/Portfolio/actions/workflows/static.yml/badge.svg)](https://github.com/narainkarthikv/Portfolio/actions/workflows/static.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 
 <h3 align="center">
   🙋 Join the Community
@@ -86,3 +88,38 @@
   <a href="https://nmoji.netlify.app/"> <img src="https://github.com/narainkarthikv/narainkarthikv/blob/main/assets/images/nmoji.jpg" height="75px" width="75px" target="_blank"/></a>
   <a href="https://contribution-cards.netlify.app/"> <img src="https://github.com/narainkarthikv/narainkarthikv/blob/main/assets/images/contribution-cards.jpg" height="75px" width="75px" target="_blank"/></a>
 </p>
+
+## 📦 Project
+
+A personal portfolio site showcasing projects, skills, and profile. Deployed via GitHub Pages.
+
+## 🚀 Quickstart
+
+View the live site:
+- https://narainkarthikv.github.io/Portfolio
+
+Run locally as a static site from the repo root:
+
+```bash
+python -m http.server 8080
+# or
+npx serve .
+```
+
+If your site content lives in `legacy/`, serve that directory:
+
+```bash
+npx serve legacy
+```
+
+## 🛠 Tech
+
+Static HTML/CSS/JS. GitHub Actions deploys to Pages using `.github/workflows/static.yml` (uploads `./legacy/`).
+
+## 🤝 Contributing
+
+See `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`. Use issue templates to report bugs or request features.
+
+## 📜 Changelog
+
+See `CHANGELOG.md` for release notes.


### PR DESCRIPTION
## 📃 Description
This PR improves the repository’s open-source readiness and developer experience by:
- Adding a Keep a Changelog-based [CHANGELOG.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CHANGELOG.md:0:0-0:0) with SemVer scaffolding
- Introducing community guidelines ([CONTRIBUTING.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CONTRIBUTING.md:0:0-0:0), [CODE_OF_CONDUCT.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CODE_OF_CONDUCT.md:0:0-0:0))
- Adding a PR template
- Enhancing [README.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/README.md:0:0-0:0) with badges and clear quickstart/contributing sections
- Verifying existing issue templates and CI workflow

Closes narainkarthikv/Portfolio#40

## ✅ Changes
- docs: add [CHANGELOG.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CHANGELOG.md:0:0-0:0) following Keep a Changelog + SemVer
- docs: add [CONTRIBUTING.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CONTRIBUTING.md:0:0-0:0)
- docs: add [CODE_OF_CONDUCT.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CODE_OF_CONDUCT.md:0:0-0:0) (Contributor Covenant reference)
- docs: add [.github/PULL_REQUEST_TEMPLATE.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/.github/PULL_REQUEST_TEMPLATE.md:0:0-0:0)
- docs: enhance [README.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/README.md:0:0-0:0) with:
  - GitHub Actions badge for Pages deploy ([.github/workflows/static.yml](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/.github/workflows/static.yml:0:0-0:0))
  - MIT license badge
  - Project, Quickstart, Tech, Contributing, and Changelog sections
- chore: confirmed [.github/ISSUE_TEMPLATE](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/.github/ISSUE_TEMPLATE:0:0-0:0) (bug/feature/other) already present
- ci: kept Pages deploy path [./legacy/](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/legacy:0:0-0:0) consistent with repo

## 🧪 How to Test
- Open README and confirm badges render and links work
- Verify new files exist:
  - [CHANGELOG.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CHANGELOG.md:0:0-0:0)
  - [CONTRIBUTING.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CONTRIBUTING.md:0:0-0:0)
  - [CODE_OF_CONDUCT.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CODE_OF_CONDUCT.md:0:0-0:0)
  - [.github/PULL_REQUEST_TEMPLATE.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/.github/PULL_REQUEST_TEMPLATE.md:0:0-0:0)
- Confirm issue templates visible when opening new issues

## 📌 Notes
- Current Pages workflow deploys [./legacy/](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/legacy:0:0-0:0) on push to `main`. If the site moves to root later, update `path` accordingly.
- Initial changelog tagged as `0.1.0` scaffold; adjust if you prefer a different starting version.

## ✔️ Acceptance Criteria
- [x] [CHANGELOG.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/CHANGELOG.md:0:0-0:0) is added and versioned
- [x] [README.md](cci:7://file:///Users/manasabalakrishhna/CascadeProjects/windsurf-project/Portfolio/README.md:0:0-0:0) is polished and includes badges
- [x] Community guidelines & templates are available and clear
- [x] CI pipeline reviewed; badge added