### PR TITLE
docs: add CHANGELOG.md for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this portfolio are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-05
+
+Initial stable release of the personal portfolio, covering the evolution from the first commit to a production-ready Astro experience.
+
+### Added
+- Migrated from a static HTML/JS portfolio to an Astro-based architecture.
+- Added Medium blog integration and a dedicated `/blog` page.
+- Added Spotify integration and expanded profile content with certifications.
+- Added Docker support for consistent local setup.
+- Added domain/CNAME support and improved deployment readiness.
+- Added stronger OSS/project documentation (contributing guides, templates, and repository governance docs).
+
+### Changed
+- Refined project cards, spacing, case-study tabs, and keyboard-based navigation.
+- Improved typography and visual design language across the portfolio.
+- Enhanced SEO practices, meta tags, and discoverability setup.
+- Modernized legacy code paths and directory organization.
+- Reworked CV/resume presentation and profile sections over multiple updates.
+
+### Fixed
+- Multiple UI/UX regressions across desktop/mobile layouts and section-level rendering.
+- Build/package issues (`pnpm` and Astro-related config adjustments).
+- RSS/JSON and content update issues.
+- Theme and animation fixes, including dark mode and custom visual effects.
+- Broken links and assorted content consistency fixes.
+
+### Notes
+- This release also restores a dedicated changelog after prior removal and aligns release history with current repository state.
+
+[1.0.0]: https://github.com/narainkarthikv/Portfolio/releases/tag/v1.0.0


### PR DESCRIPTION
### Motivation
- Restore a proper, human-readable changelog to document the portfolio history and record the `v1.0.0` stable release using the Keep a Changelog format.

### Description
- Add `CHANGELOG.md` at the repository root containing `1.0.0` release notes organized into `Added`, `Changed`, `Fixed`, and `Notes` sections.

### Testing
- No automated tests were required or executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97f112764832db1c36b8225c2ed8c)